### PR TITLE
Added encrypted messaging over Nostr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "collect.js": "4.36.1",
         "commander": "12.1.0",
         "minimal-slp-wallet": "5.12.1",
+        "nostr": "0.2.8",
         "nostr-tools": "2.8.1",
         "shelljs": "0.8.5",
         "ws": "8.18.0"
@@ -8025,6 +8026,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/noble-secp256k1": {
+      "version": "1.2.14",
+      "resolved": "http://94.130.170.209:4873/noble-secp256k1/-/noble-secp256k1-1.2.14.tgz",
+      "integrity": "sha512-GSCXyoZBUaaPwVWdYncMEmzlSUjF9J/YeEHpklYJCyg8wPuJP3NzDx0BkiwArzINkdX2HJHvUJhL6vVWPOQQcg==",
+      "deprecated": "Switch to namespaced @noble/secp256k1 for security and feature updates",
+      "license": "MIT"
+    },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
@@ -8149,6 +8157,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nostr": {
+      "version": "0.2.8",
+      "resolved": "http://94.130.170.209:4873/nostr/-/nostr-0.2.8.tgz",
+      "integrity": "sha512-p25OQiEB5x8rWWoWLRRbxtxQiaQgypaQQakSKw5+cp/SW0DXea/soMzqmTXei1I6HrcARuyfvedGTdoEU471Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "noble-secp256k1": "^1.2.14",
+        "ws": "^8.8.1"
       }
     },
     "node_modules/nostr-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,27 @@
 {
-  "name": "psf-bch-wallet",
-  "version": "3.0.0",
+  "name": "psf-msg-wallet",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "psf-bch-wallet",
-      "version": "3.0.0",
+      "name": "psf-msg-wallet",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@chris.troutner/retry-queue": "1.0.10",
+        "@noble/hashes": "1.5.0",
+        "base58-js": "2.0.0",
+        "bch-encrypt-lib": "2.1.1",
+        "bch-message-lib": "2.3.1",
         "bch-token-sweep": "2.2.1",
         "cli-table": "0.3.11",
         "collect.js": "4.36.1",
         "commander": "12.1.0",
         "minimal-slp-wallet": "5.12.1",
-        "shelljs": "0.8.5"
+        "nostr-tools": "2.8.1",
+        "shelljs": "0.8.5",
+        "ws": "8.18.0"
       },
       "devDependencies": {
         "c8": "10.1.2",
@@ -123,6 +130,16 @@
         "node": ">=10.15.1"
       }
     },
+    "node_modules/@chris.troutner/retry-queue": {
+      "version": "1.0.10",
+      "resolved": "http://94.130.170.209:4873/@chris.troutner%2fretry-queue/-/retry-queue-1.0.10.tgz",
+      "integrity": "sha512-iF+xQl3jyTATAKDVkwY85j4Npihh/MqG99bjrS0cNJDF0XQeUSMVGsdtXR6TFj8YcEgfPvgBdYGOtEFo6tTQpA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "7.3.0",
+        "p-retry": "5.1.1"
+      }
+    },
     "node_modules/@chris.troutner/retry-queue-commonjs": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@chris.troutner/retry-queue-commonjs/-/retry-queue-commonjs-1.0.8.tgz",
@@ -131,6 +148,50 @@
       "dependencies": {
         "p-queue": "4.0.0",
         "p-retry": "4.6.2"
+      }
+    },
+    "node_modules/@chris.troutner/retry-queue/node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "http://94.130.170.209:4873/@types%2fretry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "license": "MIT"
+    },
+    "node_modules/@chris.troutner/retry-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "http://94.130.170.209:4873/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/@chris.troutner/retry-queue/node_modules/p-queue": {
+      "version": "7.3.0",
+      "resolved": "http://94.130.170.209:4873/p-queue/-/p-queue-7.3.0.tgz",
+      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.7",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@chris.troutner/retry-queue/node_modules/p-retry": {
+      "version": "5.1.1",
+      "resolved": "http://94.130.170.209:4873/p-retry/-/p-retry-5.1.1.tgz",
+      "integrity": "sha512-i69WkEU5ZAL8mrmdmVviWwU+DN+IUF8f4sSJThoJ3z5A7Nn5iuO5ROX3Boye0u+uYQLOSfgFl7SuFZCjlAVbQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@colors/colors": {
@@ -844,6 +905,51 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "0.5.3",
+      "resolved": "http://94.130.170.209:4873/@noble%2fciphers/-/ciphers-0.5.3.tgz",
+      "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "http://94.130.170.209:4873/@noble%2fcurves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "http://94.130.170.209:4873/@noble%2fhashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "http://94.130.170.209:4873/@noble%2fhashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1190,6 +1296,93 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "http://94.130.170.209:4873/@scure%2fbase/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.3.1",
+      "resolved": "http://94.130.170.209:4873/@scure%2fbip32/-/bip32-1.3.1.tgz",
+      "integrity": "sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.1.0",
+        "@noble/hashes": "~1.3.1",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.1.0",
+      "resolved": "http://94.130.170.209:4873/@noble%2fcurves/-/curves-1.1.0.tgz",
+      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "http://94.130.170.209:4873/@noble%2fhashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "http://94.130.170.209:4873/@noble%2fhashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "http://94.130.170.209:4873/@scure%2fbip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "http://94.130.170.209:4873/@noble%2fhashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -1774,6 +1967,12 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/aes-js": {
+      "version": "3.1.2",
+      "resolved": "http://94.130.170.209:4873/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+      "license": "MIT"
+    },
     "node_modules/agent-base": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
@@ -2241,6 +2440,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/base58-js": {
+      "version": "2.0.0",
+      "resolved": "http://94.130.170.209:4873/base58-js/-/base58-js-2.0.0.tgz",
+      "integrity": "sha512-nAV5d32QXuGcGptSApkKpC1gGakWBnfJMNjKrYTBh4tb0szfZF+ooueFLy8T4VrY+o4SrE/TyrtUnRZcwZchaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2338,6 +2546,28 @@
       "license": "MIT",
       "dependencies": {
         "apidoc": "0.51.0"
+      }
+    },
+    "node_modules/bch-encrypt-lib": {
+      "version": "2.1.1",
+      "resolved": "http://94.130.170.209:4873/bch-encrypt-lib/-/bch-encrypt-lib-2.1.1.tgz",
+      "integrity": "sha512-709FHSVhUofFnZg9i5BbLWc9kwrw9d5ZZzFetNFcNOS1Be/kPhvON4Q1yD3uurIrcOdVIw+Sj7tddxEEabwrBA==",
+      "license": "MIT",
+      "dependencies": {
+        "eccrypto-js": "5.3.0",
+        "wif": "2.0.6"
+      },
+      "peerDependencies": {
+        "minimal-slp-wallet": ">= 5"
+      }
+    },
+    "node_modules/bch-message-lib": {
+      "version": "2.3.1",
+      "resolved": "http://94.130.170.209:4873/bch-message-lib/-/bch-message-lib-2.3.1.tgz",
+      "integrity": "sha512-xAWMRvmcP2mYTdp9KgjSQfxlJF4DTloCJrjGx0TumD3HPF9mmYZ/CiCGUAFdQk3LBCavnK0AZi9v3+JTNSnrcA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "minimal-slp-wallet": ">= 5"
       }
     },
     "node_modules/bch-token-sweep": {
@@ -3760,6 +3990,30 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/eccrypto-js": {
+      "version": "5.3.0",
+      "resolved": "http://94.130.170.209:4873/eccrypto-js/-/eccrypto-js-5.3.0.tgz",
+      "integrity": "sha512-fCPIHNr/RDSCNY9NKkrSsjkurb6Rw/d5TYVdzjJeA3E+HcF+DdaWAvhDdsAcBOGUJ6Ygs8o6b4imuvhx9t7o+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "aes-js": "3.1.2",
+        "enc-utils": "2.1.0",
+        "hash.js": "1.1.7",
+        "js-sha3": "0.8.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "2.1.0",
+        "secp256k1": "3.8.0"
+      }
+    },
+    "node_modules/eccrypto-js/node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "http://94.130.170.209:4873/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/ecurve": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
@@ -3818,6 +4072,23 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/enc-utils": {
+      "version": "2.1.0",
+      "resolved": "http://94.130.170.209:4873/enc-utils/-/enc-utils-2.1.0.tgz",
+      "integrity": "sha512-VD0eunGDyzhojePzkORWDnW88gi6tIeGb5Z6QVHugux6mMAPiXyw94fb/7WdDQEWhKMSoYRyzFFUebCqeH20PA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "4.11.8",
+        "is-typedarray": "1.0.0",
+        "typedarray-to-buffer": "3.1.5"
+      }
+    },
+    "node_modules/enc-utils/node_modules/bn.js": {
+      "version": "4.11.8",
+      "resolved": "http://94.130.170.209:4873/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -6593,6 +6864,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "http://94.130.170.209:4873/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -6846,6 +7123,12 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
       "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "license": "MIT"
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "http://94.130.170.209:4873/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -7867,6 +8150,50 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/nostr-tools": {
+      "version": "2.8.1",
+      "resolved": "http://94.130.170.209:4873/nostr-tools/-/nostr-tools-2.8.1.tgz",
+      "integrity": "sha512-lInnbSjtBHviiEpxRt4rV73XdC9lMUuaMkvsiNVpIboGwebP19w4NOx91QRfupczGTSiKxV5X3GzxRr3IvHuCw==",
+      "license": "Unlicense",
+      "dependencies": {
+        "@noble/ciphers": "^0.5.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.1",
+        "@scure/base": "1.1.1",
+        "@scure/bip32": "1.3.1",
+        "@scure/bip39": "1.2.1"
+      },
+      "optionalDependencies": {
+        "nostr-wasm": "v0.1.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nostr-tools/node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "http://94.130.170.209:4873/@noble%2fhashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nostr-wasm": {
+      "version": "0.1.0",
+      "resolved": "http://94.130.170.209:4873/nostr-wasm/-/nostr-wasm-0.1.0.tgz",
+      "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/npm": {
       "version": "10.9.0",
@@ -11347,6 +11674,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "http://94.130.170.209:4873/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -13901,6 +14240,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "http://94.130.170.209:4873/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "node_modules/typeforce": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
@@ -14487,6 +14835,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "http://94.130.170.209:4873/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "collect.js": "4.36.1",
     "commander": "12.1.0",
     "minimal-slp-wallet": "5.12.1",
+    "nostr": "0.2.8",
     "nostr-tools": "2.8.1",
     "shelljs": "0.8.5",
     "ws": "8.18.0"

--- a/package.json
+++ b/package.json
@@ -12,12 +12,19 @@
   "author": "Chris Troutner",
   "license": "MIT",
   "dependencies": {
+    "@chris.troutner/retry-queue": "1.0.10",
+    "@noble/hashes": "1.5.0",
+    "base58-js": "2.0.0",
+    "bch-encrypt-lib": "2.1.1",
+    "bch-message-lib": "2.3.1",
     "bch-token-sweep": "2.2.1",
     "cli-table": "0.3.11",
     "collect.js": "4.36.1",
     "commander": "12.1.0",
     "minimal-slp-wallet": "5.12.1",
-    "shelljs": "0.8.5"
+    "nostr-tools": "2.8.1",
+    "shelljs": "0.8.5",
+    "ws": "8.18.0"
   },
   "devDependencies": {
     "c8": "10.1.2",

--- a/psf-msg-wallet.js
+++ b/psf-msg-wallet.js
@@ -16,6 +16,8 @@ import SendTokens from './src/commands/send-tokens.js'
 import WalletSweep from './src/commands/wallet-sweep.js'
 import MsgSign from './src/commands/msg-sign.js'
 import MsgVerify from './src/commands/msg-verify.js'
+import MsgSendNostr from './src/commands/msg-send-nostr.js'
+import MsgCheckNostr from './src/commands/msg-check-nostr.js'
 
 // Instantiate the subcommands
 const walletCreate = new WalletCreate()
@@ -27,6 +29,8 @@ const sendTokens = new SendTokens()
 const walletSweep = new WalletSweep()
 const msgSign = new MsgSign()
 const msgVerify = new MsgVerify()
+const msgSendNostr = new MsgSendNostr()
+const msgCheckNostr = new MsgCheckNostr()
 
 const program = new Command()
 
@@ -90,5 +94,18 @@ program.command('msg-verify')
   .option('-m, --msg <string>', 'Cleartext message that was signed')
   .option('-a, --addr <string>', 'BCH address generated from private key that signed the message')
   .action(msgVerify.run)
+
+program.command('msg-send-nostr')
+  .description('Send an E2EE message to a BCH address over Nostr')
+  .option('-a, --addr <string>', 'BCH address to send message to')
+  .option('-n, --name <string>', 'wallet name to pay for message signal')
+  .option('-m, --msg <string>', 'Full message, which will be encrypted')
+  .option('-s, --subject <string>', 'summary message, like in an email, sent as cleartext')
+  .action(msgSendNostr.run)
+
+program.command('msg-check-nostr')
+  .description('Check for new E2EE messages')
+  .option('-n, --name <string>', 'wallet name to pay for message signal')
+  .action(msgCheckNostr.run)
 
 program.parseAsync(process.argv)

--- a/psf-msg-wallet.js
+++ b/psf-msg-wallet.js
@@ -18,6 +18,7 @@ import MsgSign from './src/commands/msg-sign.js'
 import MsgVerify from './src/commands/msg-verify.js'
 import MsgSendNostr from './src/commands/msg-send-nostr.js'
 import MsgCheckNostr from './src/commands/msg-check-nostr.js'
+import MsgReadNostr from './src/commands/msg-read-nostr.js'
 
 // Instantiate the subcommands
 const walletCreate = new WalletCreate()
@@ -31,6 +32,7 @@ const msgSign = new MsgSign()
 const msgVerify = new MsgVerify()
 const msgSendNostr = new MsgSendNostr()
 const msgCheckNostr = new MsgCheckNostr()
+const msgReadNostr = new MsgReadNostr()
 
 const program = new Command()
 
@@ -107,5 +109,11 @@ program.command('msg-check-nostr')
   .description('Check for new E2EE messages')
   .option('-n, --name <string>', 'wallet name to pay for message signal')
   .action(msgCheckNostr.run)
+
+program.command('msg-read-nostr')
+  .description('Read an E2EE message sent to your wallet, and stored on Nostr')
+  .option('-n, --name <string>', 'wallet name to pay for message signal')
+  .option('-t, --txid <string>', 'TXID of the message signal. Displayed by msg-check-nostr')
+  .action(msgReadNostr.run)
 
 program.parseAsync(process.argv)

--- a/src/commands/msg-check-nostr.js
+++ b/src/commands/msg-check-nostr.js
@@ -1,0 +1,150 @@
+/*
+  Check for received messages in a wallet
+
+  ...when Nostr is used as the medium to store encrypted messages.
+*/
+
+// Global npm libraries
+// import RetryQueue from '@chris.troutner/retry-queue'
+import EncryptLib from 'bch-encrypt-lib'
+
+// Local libraries
+import WalletUtil from '../lib/wallet-util.js'
+// import { base58_to_binary as base58ToBinary } from 'base58-js'
+// import { bytesToHex } from '@noble/hashes/utils'
+// import { finalizeEvent, getPublicKey } from 'nostr-tools/pure'
+// import { Relay, useWebSocketImplementation } from 'nostr-tools/relay'
+// import WebSocket from 'ws'
+import Table from 'cli-table'
+
+// useWebSocketImplementation(WebSocket)
+
+class MsgCheckNostr {
+  constructor () {
+    // Encapsulate Dependencies
+    this.walletUtil = new WalletUtil()
+
+    // const options = {
+    //   concurrency: 1,
+    //   attempts: 5,
+    //   retryPeriod: 1000
+    // }
+    // this.retryQueue = new RetryQueue(options)
+
+    // Bind 'this' object to all subfunctions.
+    this.run = this.run.bind(this)
+    this.validateFlags = this.validateFlags.bind(this)
+    this.msgCheck = this.msgCheck.bind(this)
+    this.filterMessages = this.filterMessages.bind(this)
+    this.displayTable = this.displayTable.bind(this)
+  }
+
+  async run (flags) {
+    try {
+      this.validateFlags(flags)
+
+      // Initialize the wallet.
+      this.bchWallet = await this.walletUtil.instanceWallet(flags.name)
+      await this.bchWallet.initialize()
+
+      // Initialize the message library.
+      this.msgLib = this.walletUtil.instanceMsgLib(this.bchWallet)
+
+      // Initialize the encryption library.
+      // To-Do: Move this instantiation to the walletUtil library.
+      this.encryptLib = new EncryptLib({ bchjs: this.bchWallet.bchjs })
+
+      // Check for new message signals on the blockchain.
+      await this.msgCheck(flags)
+
+      return true
+    } catch (err) {
+      console.error('Error in send-bch: ', err)
+      return 0
+    }
+  }
+
+  validateFlags (flags = {}) {
+    // Exit if wallet not specified.
+    const name = flags.name
+    if (!name || name === '') {
+      throw new Error('You must specify a wallet name with the -n flag.')
+    }
+
+    return true
+  }
+
+  // Primary macro function for checking messages.
+  async msgCheck (flags) {
+    try {
+      const cashAddress = this.bchWallet.walletInfo.cashAddress
+
+      // Get message signals from the blockchain.
+      console.log(`cashAddress ${cashAddress}`)
+      const messages = await this.msgLib.memo.readMsgSignal(cashAddress, 'MSG NOSTR')
+      console.log('message: ', messages)
+
+      // Filter out sent messages, so user only sees recieved messages.
+      const receiveMessages = this.filterMessages(cashAddress, messages)
+      if (!receiveMessages.length) {
+        console.log('No Messages Found!')
+        return false
+      }
+
+      // Display the messages on the screen.
+      this.displayTable(receiveMessages)
+
+      return true
+    } catch (err) {
+      console.error('Error in msgCheck()')
+      throw err
+    }
+  }
+
+  // Ignores send messages
+  // returns only received messages
+  filterMessages (bchAddress, messages) {
+    try {
+      if (!bchAddress || typeof bchAddress !== 'string') {
+        throw new Error('bchAddress must be a string.')
+      }
+      if (!Array.isArray(messages)) {
+        throw new Error('messages must be an array.')
+      }
+      const filtered = []
+
+      for (let i = 0; i < messages.length; i++) {
+        const message = messages[i]
+        if (message.sender !== bchAddress) {
+          filtered.push(message)
+        }
+      }
+      return filtered
+    } catch (error) {
+      console.log('Error in filterMessages()')
+      throw error
+    }
+  }
+
+  // Display table in a table on the command line using cli-table.
+  displayTable (data) {
+    const table = new Table({
+      head: ['Subject', 'Transaction ID'],
+      colWidths: [25, 80]
+    })
+
+    for (let i = 0; i < data.length; i++) {
+      const _data = [data[i].subject, data[i].txid]
+      table.push(_data)
+    }
+
+    const tableStr = table.toString()
+
+    // Cut down on screen spam when running unit tests.
+    console.log(tableStr)
+
+    return tableStr
+  }
+}
+
+export default MsgCheckNostr

--- a/src/commands/msg-read-nostr.js
+++ b/src/commands/msg-read-nostr.js
@@ -1,0 +1,197 @@
+/*
+  Read e2e encrypted messages that have been posted to Nostr
+*/
+
+// Global npm libraries
+import RetryQueue from '@chris.troutner/retry-queue'
+import EncryptLib from 'bch-encrypt-lib'
+import Nostr from 'nostr'
+import { bytesToHex } from '@noble/hashes/utils'
+
+// Local libraries
+import WalletUtil from '../lib/wallet-util.js'
+
+class MsgReadNostr {
+  constructor () {
+    // Encapsulate Dependencies
+    this.walletUtil = new WalletUtil()
+    this.RelayPool = Nostr.RelayPool
+    this.bytesToHex = bytesToHex
+
+    const options = {
+      concurrency: 1,
+      attempts: 5,
+      retryPeriod: 1000
+    }
+    this.retryQueue = new RetryQueue(options)
+
+    // Bind 'this' object to all subfunctions.
+    this.run = this.run.bind(this)
+    this.validateFlags = this.validateFlags.bind(this)
+    this.msgRead = this.msgRead.bind(this)
+    this.getSenderFromTx = this.getSenderFromTx.bind(this)
+    this.getAndDecrypt = this.getAndDecrypt.bind(this)
+  }
+
+  async run (flags) {
+    try {
+      this.validateFlags(flags)
+
+      // Initialize the wallet.
+      this.bchWallet = await this.walletUtil.instanceWallet(flags.name)
+      await this.bchWallet.initialize()
+
+      // Initialize the message library.
+      this.msgLib = this.walletUtil.instanceMsgLib(this.bchWallet)
+
+      // Initialize the encryption library.
+      // To-Do: Move this instantiation to the walletUtil library.
+      this.encryptLib = new EncryptLib({ bchjs: this.bchWallet.bchjs })
+
+      const { sender, message } = await this.msgRead(flags)
+      console.log(`Sender: ${sender}`)
+      console.log(`Message:\n${message}`)
+
+      return message
+    } catch (err) {
+      console.error('Error in send-bch: ', err)
+      return 0
+    }
+  }
+
+  validateFlags (flags = {}) {
+    // Exit if wallet not specified.
+    const name = flags.name
+    if (!name || name === '') {
+      throw new Error('You must specify a wallet name with the -n flag.')
+    }
+
+    // Exit if address not specified.
+    const txid = flags.txid
+    if (!txid || txid === '') {
+      throw new Error('You must specify a TXID representing a message with the -t flag.')
+    }
+
+    return true
+  }
+
+  // Primary macro/orchestration function
+  async msgRead (flags) {
+    try {
+      const { txid } = flags
+
+      // Get TX Data
+      const txDataResult = await this.bchWallet.getTxData([txid])
+      const txData = txDataResult[0]
+      // console.log(`txData: ${JSON.stringify(txData, null, 2)}`)
+
+      const sender = this.getSenderFromTx(txData)
+      // console.log('sender: ', sender)
+
+      // get the Nostr eventId from tx OP_RETURN
+      const eventId = this.getEventIdFromTx(txData)
+      console.log(`Nostr Event ID: ${eventId}`)
+
+      // Get the encrypted message from Nostr and decrypt it.
+      const message = await this.getAndDecrypt(eventId)
+
+      return { sender, message }
+    } catch (error) {
+      console.error('Error in msgRead()')
+      throw error
+    }
+  }
+
+  // Given data on a TX, get the sender. This is assumed to be the address
+  // behind the first input of the transaction.
+  getSenderFromTx (txData) {
+    const sender = txData.vin[0].address
+
+    return sender
+  }
+
+  // decode and get transaction eventId from OP_RETURN
+  getEventIdFromTx (txData) {
+    try {
+      // Input validation
+      if (!txData) {
+        throw new Error('txData object is required.')
+      }
+      let eventId = ''
+
+      // Loop through all the vout entries in this transaction.
+      for (let j = 0; j < txData.vout.length; j++) {
+        // for (let j = 0; j < 5; j++) {
+        const thisVout = txData.vout[j]
+        // console.log(`thisVout: ${JSON.stringify(thisVout,null,2)}`)
+
+        // Assembly code representation of the transaction.
+        const asm = thisVout.scriptPubKey.asm
+        // console.log(`asm: ${asm}`)
+
+        // Decode the transactions assembly code.
+        const msg = this.msgLib.memo.decodeTransaction(asm, '-21101')
+
+        if (msg) {
+          // Filter the code to see if it contains an IPFS eventId And Subject.
+          const data = this.msgLib.memo.filterMSG(msg, 'MSG NOSTR')
+          // console.log('data: ', data)
+          if (data && data.hash) {
+            eventId = data.hash
+          }
+        }
+      }
+
+      if (!eventId) {
+        throw new Error('Message not found!')
+      }
+
+      return eventId
+    } catch (error) {
+      console.log('Error in getEventIdFromTx()')
+      throw error
+    }
+  }
+
+  // Retrieve the encrypted data from a Nostr relay and decrypt it.
+  async getAndDecrypt (eventId) {
+    // Define the relay pool.
+    const psf = 'wss://nostr-relay.psfoundation.info'
+    const relays = [psf]
+    const pool = this.RelayPool(relays)
+
+    const nostrData = new Promise((resolve, reject) => {
+      pool.on('open', relay => {
+        relay.subscribe('REQ', { ids: [eventId] })
+      })
+
+      pool.on('eose', relay => {
+        relay.close()
+      })
+
+      pool.on('event', (relay, subId, ev) => {
+        resolve(ev)
+      })
+    })
+
+    const event = await nostrData
+    // console.log('event: ', event)
+
+    const encryptedData = event.content
+
+    // decrypt message
+    const messageHex = await this.encryptLib.encryption.decryptFile(
+      this.bchWallet.walletInfo.privateKey,
+      encryptedData
+    )
+    // console.log(`messageHex: ${messageHex}`)
+
+    const buf = Buffer.from(messageHex, 'hex')
+    const decryptedMsg = buf.toString('utf8')
+    // console.log('Message :', decryptedMsg)
+
+    return decryptedMsg
+  }
+}
+
+export default MsgReadNostr

--- a/src/commands/msg-send-nostr.js
+++ b/src/commands/msg-send-nostr.js
@@ -1,0 +1,283 @@
+/*
+  This command will send an E2EE message to a BCH address.
+
+  1. The public key for the given address is retrieved from the blockchain. This
+  requires that the address has made at least one transaction.
+  2. The message is encrypted using the public key.
+  3. The encrypted message is uploaded to a Nostr relay.
+  4. An notification signal is broadcasted to the blockchain to notify the receiver of the message.
+*/
+
+// Global npm libraries
+import RetryQueue from '@chris.troutner/retry-queue'
+import EncryptLib from 'bch-encrypt-lib'
+import { base58_to_binary as base58ToBinary } from 'base58-js'
+// import { bytesToHex } from '@noble/hashes/utils'
+import { finalizeEvent, getPublicKey } from 'nostr-tools/pure'
+import { Relay, useWebSocketImplementation } from 'nostr-tools/relay'
+import WebSocket from 'ws'
+
+// Local libraries
+import WalletUtil from '../lib/wallet-util.js'
+
+useWebSocketImplementation(WebSocket)
+
+class MsgSendNostr {
+  constructor () {
+    // Encapsulate Dependencies
+    this.walletUtil = new WalletUtil()
+
+    const options = {
+      concurrency: 1,
+      attempts: 5,
+      retryPeriod: 1000
+    }
+    this.retryQueue = new RetryQueue(options)
+
+    // Bind 'this' object to all subfunctions.
+    this.run = this.run.bind(this)
+    this.validateFlags = this.validateFlags.bind(this)
+    this.msgSend = this.msgSend.bind(this)
+    this.encryptMsgStr = this.encryptMsgStr.bind(this)
+    this.uploadToNostr = this.uploadToNostr.bind(this)
+    this.createNostrPubKey = this.createNostrPubKey.bind(this)
+    this.sendMsgSignal = this.sendMsgSignal.bind(this)
+    this.signalMessage = this.signalMessage.bind(this)
+    this.encryptMsg = this.encryptMsg.bind(this)
+  }
+
+  async run (flags) {
+    try {
+      this.validateFlags(flags)
+
+      // Initialize the wallet.
+      this.bchWallet = await this.walletUtil.instanceWallet(flags.name)
+      await this.bchWallet.initialize()
+
+      // Initialize the message library.
+      this.msgLib = this.walletUtil.instanceMsgLib(this.bchWallet)
+
+      // Initialize the encryption library.
+      // To-Do: Move this instantiation to the walletUtil library.
+      this.encryptLib = new EncryptLib({ bchjs: this.bchWallet.bchjs })
+
+      // Sweep any BCH and tokens from the private key.
+      const txid = await this.msgSend(flags)
+
+      console.log(`BCH successfully swept from private key ${flags.wif}`)
+      console.log(`TXID: ${txid}`)
+      console.log('\nView this transaction on a block explorer:')
+      console.log(`https://bch.loping.net/tx/${txid}`)
+
+      return true
+    } catch (err) {
+      console.error('Error in send-bch: ', err)
+      return 0
+    }
+  }
+
+  validateFlags (flags = {}) {
+    // Exit if wallet not specified.
+    const name = flags.name
+    if (!name || name === '') {
+      throw new Error('You must specify a wallet name with the -n flag.')
+    }
+
+    // Exit if address not specified.
+    const addr = flags.addr
+    if (!addr || addr === '') {
+      throw new Error('You must specify an address to send to with the -a flag.')
+    }
+
+    // Exit if message not specified.
+    const msg = flags.msg
+    if (!msg || msg === '') {
+      throw new Error('You must specify a message with the -m flag.')
+    }
+
+    return true
+  }
+
+  // Orchestration function
+  async msgSend (flags) {
+    try {
+      // Encrypt the message with the receivers public key.
+      const encryptedStr = await this.encryptMsgStr(flags)
+
+      const eventId = await this.uploadToNostr({ encryptedStr })
+      console.log('Encrypted message uploaded to Nostr with post event ID: ', eventId)
+
+      // Broadcast a PS001 signal on the blockchain, to signal the recipient
+      // that they have a message waiting.
+      const txid = await this.sendMsgSignal(flags, eventId)
+
+      return txid
+    } catch (err) {
+      console.error('Error in msgSend()')
+      throw err
+    }
+  }
+
+  // Encrypt the message string. Returns a hexidecimal string representing
+  // the encrypted message.
+  async encryptMsgStr (flags) {
+    try {
+      const { addr, msg } = flags
+
+      // Get public Key for reciever from the blockchain.
+      // const pubKey = await this.walletService.getPubKey(bchAddress)
+      const publicKey = await this.retryQueue.addToQueue(this.bchWallet.getPubKey, addr)
+      // const publicKey = pubKey.pubkey.publicKey
+      console.log(`BCH Public Key: ${JSON.stringify(publicKey, null, 2)}`)
+
+      // Encrypt the message using the recievers public key.
+      const encryptedMsg = await this.encryptMsg(publicKey, msg)
+      console.log(`encryptedMsg: ${JSON.stringify(encryptedMsg, null, 2)}`)
+
+      return encryptedMsg
+    } catch (err) {
+      console.error('Error in encryptMsgStr()')
+      throw err
+    }
+  }
+
+  // Upload the encrypted message to Nostr. Returns the event ID of the posted
+  // message.
+  async uploadToNostr (inObj = {}) {
+    try {
+      const { encryptedStr } = inObj
+
+      // Generate a Nostr pub key from the private key of this wallet.
+      const { privKeyBuf, nostrPubKey } = this.createNostrPubKey()
+      console.log('nostrPubKey: ', nostrPubKey)
+
+      const psfRelay = 'wss://nostr-relay.psfoundation.info'
+
+      // Generate a Nostr post.
+      const eventTemplate = {
+        kind: 1,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [],
+        content: encryptedStr
+      }
+
+      // Sign the post
+      const signedEvent = finalizeEvent(eventTemplate, privKeyBuf)
+      // console.log('signedEvent: ', signedEvent)
+      const eventId = signedEvent.id
+
+      // Connect to a relay.
+      const relay = await Relay.connect(psfRelay)
+      console.log(`connected to ${relay.url}`)
+
+      // Publish the message to the relay.
+      await relay.publish(signedEvent)
+
+      // Close the connection to the relay.
+      relay.close()
+
+      return eventId
+    } catch (err) {
+      console.error('Error in uploadToNostr()')
+      throw err
+    }
+  }
+
+  // Generate a Nostr pubkey from the private key for this wallet.
+  createNostrPubKey () {
+    const wif = this.bchWallet.walletInfo.privateKey
+    // console.log('wif: ', wif)
+
+    // Extract the privaty key from the WIF, using this guide:
+    // https://learnmeabitcoin.com/technical/keys/private-key/wif/
+    const wifBuf = base58ToBinary(wif)
+    const privKeyBuf = wifBuf.slice(1, 33)
+
+    // const privKeyHex = bytesToHex(privKeyBuf)
+
+    const nostrPubKey = getPublicKey(privKeyBuf)
+
+    return { privKeyBuf, nostrPubKey }
+  }
+
+  // Generate and broadcast a PS001 message signal.
+  async sendMsgSignal (flags, eventId) {
+    const { addr, subject } = flags
+
+    // Wait a couple seconds to let the indexer update its UTXO state.
+    await this.bchWallet.bchjs.Util.sleep(2000)
+
+    // Update the UTXO store in the wallet.
+    await this.bchWallet.getUtxos()
+
+    // Sign Message
+    const txHex = await this.signalMessage(eventId, addr, subject)
+
+    // Broadcast Transaction
+    const txidStr = await this.bchWallet.ar.sendTx(txHex)
+    console.log(`Signal Transaction ID : ${JSON.stringify(txidStr, null, 2)}`)
+
+    return txidStr
+  }
+
+  // Generate a PS001 signal message to write to the blockchain.
+  // https://github.com/Permissionless-Software-Foundation/specifications/blob/master/ps001-media-sharing.md
+  async signalMessage (eventId, bchAddress, subject) {
+    try {
+      if (!eventId || typeof eventId !== 'string') {
+        throw new Error('eventId must be a string')
+      }
+      if (!bchAddress || typeof bchAddress !== 'string') {
+        throw new Error('bchAddress must be a string')
+      }
+      if (!subject || typeof subject !== 'string') {
+        throw new Error('subject must be a string')
+      }
+
+      // Generate the hex transaction containing the PS001 message signal.
+      const txHex = await this.msgLib.memo.writeMsgSignalNostr(
+        eventId,
+        [bchAddress],
+        subject
+      )
+
+      if (!txHex) {
+        throw new Error('Could not build a hex transaction')
+      }
+
+      return txHex
+    } catch (error) {
+      console.log('Error in signalMessage')
+      throw error
+    }
+  }
+
+  // Encrypt a message using encryptLib
+  async encryptMsg (pubKey, msg) {
+    try {
+      // Input validation
+      if (!pubKey || typeof pubKey !== 'string') {
+        throw new Error('pubKey must be a string')
+      }
+      if (!msg || typeof msg !== 'string') {
+        throw new Error('msg must be a string')
+      }
+
+      const buff = Buffer.from(msg)
+      const hex = buff.toString('hex')
+
+      const encryptedStr = await this.encryptLib.encryption.encryptFile(
+        pubKey,
+        hex
+      )
+      // console.log(`encryptedStr: ${JSON.stringify(encryptedStr, null, 2)}`)
+
+      return encryptedStr
+    } catch (error) {
+      console.log('Error in encryptMsg()')
+      throw error
+    }
+  }
+}
+
+export default MsgSendNostr

--- a/src/lib/wallet-util.js
+++ b/src/lib/wallet-util.js
@@ -6,6 +6,7 @@
 import { promises as fs } from 'fs'
 import { readFile } from 'fs/promises'
 import BchWallet from 'minimal-slp-wallet'
+import MsgLib from 'bch-message-lib'
 
 // Local libraries
 import config from '../../config/index.js'
@@ -19,9 +20,12 @@ class WalletUtil {
     this.fs = fs
     this.config = config
     this.BchWallet = BchWallet
+    this.MsgLib = MsgLib
 
     // Bind 'this' object to all subfunctions.
     this.saveWallet = this.saveWallet.bind(this)
+    this.instanceWallet = this.instanceWallet.bind(this)
+    this.instanceMsgLib = this.instanceMsgLib.bind(this)
   }
 
   // Save wallet data to a JSON file.
@@ -64,6 +68,17 @@ class WalletUtil {
       console.error('Error in wallet-util.js/instanceWallet()')
       throw err
     }
+  }
+
+  // Instantiate the bch-message-lib library with an instance of minimal-slp-wallet.
+  instanceMsgLib (wallet) {
+    if (!wallet) {
+      throw new Error('Must pass instance of minimal-slp-wallet.')
+    }
+
+    const msgLib = new this.MsgLib({ wallet })
+
+    return msgLib
   }
 }
 

--- a/test/unit/lib/wallet-util.unit.js
+++ b/test/unit/lib/wallet-util.unit.js
@@ -70,4 +70,16 @@ describe('#wallet-util', () => {
       }
     })
   })
+
+  describe('#instanceMsgLib', () => {
+    it('should throw an error if wallet is not specified', () => {
+      try {
+        uut.instanceMsgLib()
+
+        assert.fail('Unexpected code path')
+      } catch (err) {
+        assert.include(err.message, 'Must pass instance of minimal-slp-wallet.')
+      }
+    })
+  })
 })


### PR DESCRIPTION
This PR adds the `msg-check-nostr`, `msg-send-nostr`, and `msg-read-nostr` commands. These are used to send encrypted messages between BCH addresses. The encrypted message is stored on a Nostr relay while it waits for the receiver to read it.