### PR TITLE
Send and Read mods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .wallets/
 coverage/
 addrs.txt
+files/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This software requires node.js v20 or higher. Instructions for installation:
 This fork retains all the commands available in [psf-bch-wallet](https://github.com/Permissionless-Software-Foundation/psf-bch-wallet). Check that README for additional commands.
 
 -----
+-----
 
 #### Check For New Messages
 
@@ -42,15 +43,34 @@ Check for new messages. If your address has recieved a message signal, the TXID 
 
 Send an end-to-end encrypted message to a BCH address. The 'subject' is not encrypted, but the message contents are. The receiver will need to have made at least one transaction with their address in order to send them a message. That way, their public key can be retrieved from the blockchain.
 
+The command requires either the `-m` or the `-j` flag. `-m` is used to send a simple message from the command line. The `-j` flag allows for large complex messages with text and data to be passed. `-j` allows you to use a JSON files in the `files/` directory as a message. It must contain a `messages` property, but can include other properties for passing data. 
+
 ##### Arguments
 - `-n` - flag to specify the wallet paying for the message signal (required).
-- `-s` - An un-encrypted subject line (optional).
-- `-m` - A string of text to send as a message. This will be encrypted with the receivers public key. (required)
 - `-a` - The BCH address of the receiver. (required)
+- `-s` - An un-encrypted subject line (optional).
+- `-m` - A string of text to send as a message. This will be encrypted with the receivers public key.
+- `-j` - The file name in the `files/` directory containing the message.
+
 
 ##### Example
 
 - `node psf-msg-wallet.js msg-nostr-send -n wallet1 -s test -m "This is an encrypted message" -a bitcoincash:qqfrps47nxdvak55h3x97dqmglcaczegusma02uhqt`
+
+- `node psf-msg-wallet.js msg-nostr-send -n wallet1 -s test -j test-msg.json -a bitcoincash:qqfrps47nxdvak55h3x97dqmglcaczegusma02uhqt`
+
+-----
+
+#### Convert a Text File to JSON
+
+This command is useful command for sending large encrypted messages. Put your long message into a text file in the `files/` directory, and this command will parse it into a JSON object. You can then add any extra data to the JSON object that you'd like to have included with the message.
+
+##### Arguments
+- `-f` - filename for the text file in the `files/` directory (required).
+
+##### Example
+
+- `node psf-msg-wallet.js txt2json -f test-file.txt`
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This software requires node.js v20 or higher. Instructions for installation:
 
 This fork retains all the commands available in [psf-bch-wallet](https://github.com/Permissionless-Software-Foundation/psf-bch-wallet). Check that README for additional commands.
 
+-----
+
 #### Check For New Messages
 
 Check for new messages. If your address has recieved a message signal, the TXID of the message signal will be displayed. You'll need that TXID to download the message for decrypting and reading.
@@ -34,6 +36,7 @@ Check for new messages. If your address has recieved a message signal, the TXID 
 ##### Example
 - `node psf-msg-wallet.js msg-nostr-check -n wallet1`
 
+-----
 
 #### Send E2EE Message
 
@@ -49,6 +52,7 @@ Send an end-to-end encrypted message to a BCH address. The 'subject' is not encr
 
 - `node psf-msg-wallet.js msg-nostr-send -n wallet1 -s test -m "This is an encrypted message" -a bitcoincash:qqfrps47nxdvak55h3x97dqmglcaczegusma02uhqt`
 
+-----
 
 #### Read E2EE Message
 
@@ -66,8 +70,13 @@ Download an E2EE message from a Nostr relay, and decrypt it using the private ke
 
 
 -----
+-----
 
 ### File Commands
+
+These commands are useful for working with the [PSFFPP](https://psffpp.com) to upload a file. A link to the file can then be included in message.
+
+-----
 
 #### Stage a File for Pinning
 
@@ -81,6 +90,7 @@ Stage a file for pinning to the [PSF IPFS network](https://psffpp.com).
 
 - `node psf-msg-wallet.js file-stage -f test.txt`
 
+-----
 
 #### Pin a Staged File
 

--- a/files/README.md
+++ b/files/README.md
@@ -1,0 +1,6 @@
+# files
+
+This directory is used to hold temporary files. Messages that should include data
+or long-form content can be put here. Data attached to a message will be downloaded
+here.
+

--- a/psf-msg-wallet.js
+++ b/psf-msg-wallet.js
@@ -21,6 +21,8 @@ import MsgNostrCheck from './src/commands/msg-nostr-check.js'
 import MsgNostrRead from './src/commands/msg-nostr-read.js'
 import FileStage from './src/commands/file-stage.js'
 import FilePin from './src/commands/file-pin.js'
+import Txt2Json from './src/commands/txt2json.js'
+
 // Instantiate the subcommands
 const walletCreate = new WalletCreate()
 const walletList = new WalletList()
@@ -36,6 +38,8 @@ const msgNostrCheck = new MsgNostrCheck()
 const msgNostrRead = new MsgNostrRead()
 const fileStage = new FileStage()
 const filePin = new FilePin()
+const txt2Json = new Txt2Json()
+
 const program = new Command()
 
 program
@@ -100,11 +104,12 @@ program.command('msg-verify')
   .action(msgVerify.run)
 
 program.command('msg-nostr-send')
-  .description('Send an E2EE message to a BCH address over Nostr')
+  .description('Send an E2EE message to a BCH address over Nostr. Insert the message directly with the -m flag, or use a JSON file with -j flag.')
   .option('-a, --addr <string>', 'BCH address to send message to')
   .option('-n, --name <string>', 'wallet name to pay for message signal')
   .option('-m, --msg <string>', 'Full message, which will be encrypted')
   .option('-s, --subject <string>', 'summary message, like in an email, sent as cleartext')
+  .option('-j, --json <string>', 'File name in the files directory containing the message in JSON format')
   .action(msgNostrSend.run)
 
 program.command('msg-nostr-check')
@@ -130,5 +135,10 @@ program.command('file-pin')
   .option('-s, --size <string>', 'File size in MB. Use 1 for files less than 1MB.')
   .option('-f, --filename <string>', 'Name and extension of the file to be pinned')
   .action(filePin.run)
+
+program.command('txt2json')
+  .description('Convert a txt file to a JSON object')
+  .option('-f, --file <string>', 'full path to txt file to be converted')
+  .action(txt2Json.run)
 
 program.parseAsync(process.argv)

--- a/src/commands/file-pin.js
+++ b/src/commands/file-pin.js
@@ -49,7 +49,7 @@ class FileStage {
       console.log(`pobTxid: https://bch.loping.net/tx/${pobTxid}`)
       console.log(`claimTxid: https://bch.loping.net/tx/${claimTxid}`)
       console.log(`Check pinning status: https://pin.fullstack.cash/ipfs/pin-status/${flags.cid}`)
-      console.log(`Once pinned, your file will be accessible here:`)
+      console.log('Once pinned, your file will be accessible here:')
       console.log(`https://pin.fullstack.cash/ipfs/view/${flags.cid}`)
 
       return true

--- a/src/commands/msg-nostr-read.js
+++ b/src/commands/msg-nostr-read.js
@@ -31,6 +31,7 @@ class MsgNostrRead {
     this.validateFlags = this.validateFlags.bind(this)
     this.msgRead = this.msgRead.bind(this)
     this.decryptMsg = this.decryptMsg.bind(this)
+    this.formatMsg = this.formatMsg.bind(this)
   }
 
   async run (flags) {
@@ -48,7 +49,11 @@ class MsgNostrRead {
       const { sender, message } = await this.msgRead(flags)
 
       // Decrypt the message
-      const clearMsg = await this.decryptMsg({ encryptedMsgHex: message })
+      let clearMsg = await this.decryptMsg({ encryptedMsgHex: message })
+      // console.log('clearMsg (1): ', clearMsg)
+
+      // Format the message
+      clearMsg = await this.formatMsg(clearMsg)
 
       console.log(`Sender: ${sender}`)
       console.log(`Message:\n${clearMsg}`)
@@ -116,6 +121,24 @@ class MsgNostrRead {
       throw err
     }
   }
-}
 
+  // Format the message. Test to see if the message is a JSON object. If it is,
+  // parse the JSON and return the message component. If it is not JSON, then
+  // return the message as is.
+  formatMsg (msg) {
+    try {
+      let msgOut = ''
+
+      try {
+        msgOut = JSON.parse(msg)
+        return msgOut.message
+      } catch (err) {
+        return msg
+      }
+    } catch (err) {
+      console.error('Error in formatMsg(): ', err)
+      throw err
+    }
+  }
+}
 export default MsgNostrRead

--- a/src/commands/msg-nostr-send.js
+++ b/src/commands/msg-nostr-send.js
@@ -11,6 +11,7 @@
 // Global npm libraries
 import RetryQueue from '@chris.troutner/retry-queue'
 import BchNostr from 'bch-nostr'
+import fs from 'fs'
 
 // Local libraries
 import WalletUtil from '../lib/wallet-util.js'
@@ -80,8 +81,17 @@ class MsgNostrSend {
 
     // Exit if message not specified.
     const msg = flags.msg
-    if (!msg || msg === '') {
-      throw new Error('You must specify a message with the -m flag.')
+    if ((!msg || msg === '') && (!flags.json || flags.json === '')) {
+      throw new Error('You must specify a message with the -m flag, or use a JSON file with -j flag.')
+    }
+
+    // Exit if JSON file not found.
+    const jsonFile = flags.json
+    if (jsonFile && jsonFile !== '') {
+      const filePath = `./files/${jsonFile}`
+      if (!fs.existsSync(filePath)) {
+        throw new Error(`JSON file ${jsonFile} not found.`)
+      }
     }
 
     return true
@@ -112,7 +122,22 @@ class MsgNostrSend {
   // the encrypted message.
   async encryptMsgStr (flags) {
     try {
-      const { addr, msg } = flags
+      const { addr, json } = flags
+      let { msg } = flags
+
+      // Retrieve the message from a JSON file if specified.
+      if (json) {
+        // Read in the file.
+        const filePath = `./files/${json}`
+        msg = fs.readFileSync(filePath, 'utf8')
+
+        // Check that the JSON file contains the 'message' property.
+        const msgObj = JSON.parse(msg)
+        if (!msgObj.message) {
+          throw new Error(`JSON file ${json} must contain a 'message' property.`)
+        }
+      }
+      console.log('encryptMsgStr() clear-text message: ', msg)
 
       // Get public Key for reciever, from the blockchain.
       const publicKey = await this.retryQueue.addToQueue(this.bchWallet.getPubKey, addr)

--- a/src/commands/txt2json.js
+++ b/src/commands/txt2json.js
@@ -1,0 +1,45 @@
+/*
+  This is a utility command that will convert a txt file to a JSON object.
+  This tool is useful for converting a large message that could contain multiple
+  paragraphs, links, special characters, etc. into a one-line string that can
+  be included in a JSON file. That file can then be used as input for the
+  msg-nostr-send command with the -j flag.
+
+  Example:
+  $ psf-msg-wallet txt-2-json -f test-msg.txt
+*/
+
+// Global npm libraries
+import fs from 'fs'
+
+class Txt2Json {
+  constructor () {
+    this.fs = fs
+  }
+
+  run (flags) {
+    try {
+      const { file } = flags
+
+      const fileContent = fs.readFileSync(`./files/${file}`, 'utf8')
+
+      // Escape special characters for JSON
+      const jsonOutput = {
+        message: fileContent
+      }
+
+      // Convert to JSON string
+      const jsonString = JSON.stringify(jsonOutput, null, 2)
+
+      // Output the JSON string to the console
+      console.log(jsonString)
+
+      return true
+    } catch (err) {
+      console.error('Error in txt-2-json: ', err)
+      return 0
+    }
+  }
+}
+
+export default Txt2Json


### PR DESCRIPTION
I'm been working on a downstream fork of this repo (psf-mc-wallet) and realized that this upstream repository needs some changes:

- msg-nostr-send - Works the same with the -m flag, but adds a -j flag so that JSON can be attached as the message instead. This allows passing large messages as well as data and metadata into the encrypted message.
- msg-nostr-read - Modified to support the changes in msg-nostr-send
- txt2json - will read in a large text file and convert it to a JSON object. This is useful for sending large messages with the msg-nostr-send command.